### PR TITLE
chore(argocd-sync-wait): update variables

### DIFF
--- a/.github/actions/argocd-sync-wait/action.yaml
+++ b/.github/actions/argocd-sync-wait/action.yaml
@@ -2,11 +2,11 @@ name: 🗘 Argocd sync and wait
 inputs:
   ARGOCD_SERVER_URL:
     type: string
-    default: argocd.services.gtowiz.com
+    default: grpc-argocd.services.gtowiz.com
     description: Argocd server endpoint url.
   ARGOCD_VERSION:
     type: string
-    default: v2.14.11
+    default: v3.3.6
     description: argocd cli version.
   ARGOCD_APP_NAME:
     type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration parameters for the continuous deployment synchronization service
  * Server communication endpoint now uses gRPC-based infrastructure (`grpc-argocd.services.gtowiz.com`)
  * ArgoCD platform version upgraded from v2.14.11 to v3.3.6

These changes update the default settings and infrastructure used by automated application synchronization and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->