### PR TITLE
fix(.github): [WSP-13] use TICKET-ID placeholder in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ## Linear Ticket
 
-Refs: [OPS-XX](https://linear.app/gto-wizard/issue/OPS-XX)
+Refs: [TICKET-ID](https://linear.app/gto-wizard/issue/TICKET-ID)
 
 ## Environments Affected
 


### PR DESCRIPTION
## Summary

- Replace `OPS-XX` placeholder in the PR template with `TICKET-ID` so it's unambiguously a placeholder and not mistaken for a real (incomplete) ticket

## Linear Ticket

Refs: [WSP-13](https://linear.app/gto-wizard/issue/WSP-13)

## Environments Affected

- [ ] dev
- [ ] prod
- [ ] Both
- [x] N/A (module/template — no direct environment impact)

## Changes

`.github/PULL_REQUEST_TEMPLATE.md`: `OPS-XX` → `TICKET-ID` in the Linear Ticket section.

## Validation

- [ ] tg-apply plan reviewed (Terraform repos)
- [ ] kubectl apply --dry-run=client passed (K8s repos)
- [x] No hardcoded secrets — all sensitive values via AWS Secrets Manager / env refs

## Rollback Plan

Revert the commit — no infrastructure affected.

## Checklist

- [x] PR title follows `type(module/env): [ISSUE-ID] description` where module is an area within the repo (e.g. `s3/dev`, `iam/prod`, `gto-wizard/all`) and env is the environment affected
- [x] Linear ticket referenced above
- [x] `review-devops` label added to this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template placeholder references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->