### PR TITLE
fix(argocd-sync-wait): add ~/.local/bin to PATH after downloading argocd binary

### DIFF
--- a/.github/actions/argocd-sync-wait/action.yaml
+++ b/.github/actions/argocd-sync-wait/action.yaml
@@ -33,6 +33,7 @@ runs:
         curl -sL --create-dirs -o ~/.local/bin/argocd \
           "https://github.com/argoproj/argo-cd/releases/download/${{ inputs.ARGOCD_VERSION }}/argocd-linux-amd64"
         chmod +x ~/.local/bin/argocd
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Prepare app list
       id: prepare

--- a/.github/actions/argocd-sync-wait/action.yaml
+++ b/.github/actions/argocd-sync-wait/action.yaml
@@ -2,7 +2,7 @@ name: 🗘 Argocd sync and wait
 inputs:
   ARGOCD_SERVER_URL:
     type: string
-    default: argocd.services.gtowiz.com
+    default: grpc-argocd.services.gtowiz.com
     description: Argocd server endpoint url.
   ARGOCD_VERSION:
     type: string

--- a/.github/actions/argocd-sync-wait/action.yaml
+++ b/.github/actions/argocd-sync-wait/action.yaml
@@ -2,7 +2,7 @@ name: 🗘 Argocd sync and wait
 inputs:
   ARGOCD_SERVER_URL:
     type: string
-    default: grpc-argocd.services.gtowiz.com
+    default: argocd.services.gtowiz.com
     description: Argocd server endpoint url.
   ARGOCD_VERSION:
     type: string


### PR DESCRIPTION
## Summary

- Add `echo "$HOME/.local/bin" >> "$GITHUB_PATH"` to the argocd download step so the binary is on `$PATH` for all subsequent steps

The composite action downloads the argocd CLI to `~/.local/bin/argocd` but never adds that directory to `$GITHUB_PATH`. This causes `argocd: command not found` on runners where `~/.local/bin` is not in the default `$PATH` — specifically the new ci-cluster ARC runners.

Old services-cluster runners had `~/.local/bin` in their `$PATH` by default (image or profile); the new CI runners don't. One-line fix adds the dir to `$GITHUB_PATH` immediately after the download so it is available to all subsequent steps in any caller workflow.

## Test plan

- [ ] Merge this PR
- [ ] Update pinned SHA in solver-service-watcher (and any other affected repos) to the new commit SHA
- [ ] Re-run a deployment that previously failed with `argocd: command not found` and confirm the ArgoCD sync & wait step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated so the deployment CLI is added to runners' PATH after installation, ensuring the tool is available to subsequent steps.
  * Reduces intermittent workflow failures and improves consistency of deployment-related runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->