### PR TITLE
feat(setup-warp): add Cloudflare WARP proxy-mode composite action

### DIFF
--- a/.github/actions/setup-warp/action.yaml
+++ b/.github/actions/setup-warp/action.yaml
@@ -1,0 +1,110 @@
+name: "Setup Cloudflare WARP"
+description: "Install and connect Cloudflare WARP in proxy mode using service token auth"
+
+inputs:
+  organization:
+    description: "Cloudflare Zero Trust organization name"
+    required: true
+  auth-client-id:
+    description: "Cloudflare Access service token client ID"
+    required: true
+  auth-client-secret:
+    description: "Cloudflare Access service token client secret"
+    required: true
+  proxy-port:
+    description: "WARP proxy listen port"
+    required: false
+    default: "40000"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure sudo is available
+      shell: bash
+      run: |
+        if ! command -v sudo &>/dev/null; then
+          apt-get update && apt-get install -y sudo
+        fi
+
+    - name: Write MDM config
+      shell: bash
+      run: |
+        sudo mkdir -p /var/lib/cloudflare-warp
+        # `tee > /dev/null` — don't echo the auth-client-secret (the heredoc
+        # body) to the job log. GitHub's secret masker is line-based and
+        # brittle with XML-encoded values; this is belt-and-braces.
+        cat <<-XMLEOF | sudo tee /var/lib/cloudflare-warp/mdm.xml > /dev/null
+        <dict>
+          <key>organization</key>
+          <string>${{ inputs.organization }}</string>
+          <key>auth_client_id</key>
+          <string>${{ inputs.auth-client-id }}</string>
+          <key>auth_client_secret</key>
+          <string>${{ inputs.auth-client-secret }}</string>
+          <key>warp_enabled</key>
+          <true/>
+          <key>onboarding</key>
+          <false/>
+          <key>mode</key>
+          <string>proxy</string>
+          <key>proxy_port</key>
+          <integer>${{ inputs.proxy-port }}</integer>
+        </dict>
+        XMLEOF
+
+    - name: Install Cloudflare WARP
+      shell: bash
+      run: |
+        sudo apt-get update && \
+        sudo apt-get install -y \
+          gnupg \
+          ca-certificates \
+          lsb-release \
+          curl
+
+        curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" \
+          | sudo tee /etc/apt/sources.list.d/cloudflare-client.list
+
+        sudo apt-get update && sudo apt-get install -y cloudflare-warp
+
+    - name: Start and connect WARP
+      shell: bash
+      run: |
+        sudo mkdir -p /var/log
+        sudo nohup warp-svc >> /tmp/warp-svc.log 2>&1 &
+        echo "warp-svc PID: $!"
+        sleep 2
+
+        warp_svc_ready=false
+        for i in $(seq 1 10); do
+          if warp-cli status >/dev/null 2>&1; then
+            warp_svc_ready=true
+            echo "warp-svc is up"
+            break
+          fi
+          sleep 1
+        done
+        if [ "$warp_svc_ready" != "true" ]; then
+          echo "warp-svc did not become ready after 10s"
+          echo "warp-cli status:"
+          warp-cli status || true
+          exit 1
+        fi
+
+        warp-cli connect
+        warp_connected=false
+        for i in $(seq 1 30); do
+          warp_status="$(warp-cli status 2>&1 || true)"
+          if echo "$warp_status" | grep -q "Connected"; then
+            warp_connected=true
+            echo "WARP connected after ${i}s"
+            break
+          fi
+          sleep 1
+        done
+        if [ "$warp_connected" != "true" ]; then
+          echo "WARP not connected after 30s"
+          echo "$warp_status"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ Kubernetes ArgoCD sync and wait utility. Waits for application sync and healthy 
     ARGOCD_APP_NAMES: "my-app-dev"
     ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
 ```
+
+### `setup-warp`
+Installs Cloudflare WARP and connects it in **proxy mode** so subsequent steps can reach internal services (e.g. `grafana.gtowiz.com`) over an authenticated tunnel. The proxy listens on `localhost:<proxy-port>` (default `40000`) — point `curl --proxy` or `HTTP_PROXY` / `HTTPS_PROXY` env vars at it.
+
+```yaml
+- uses: gto-wizard/actions-templates/.github/actions/setup-warp@main
+  with:
+    organization: gtowizard
+    auth-client-id: ${{ vars.CF_GITHUB_ACTIONS_DIND_ACCESS_CLIENT_ID }}
+    auth-client-secret: ${{ secrets.CF_GITHUB_ACTIONS_DIND_ACCESS_CLIENT_SECRET }}
+
+# Then route requests through the proxy:
+- run: curl --proxy http://localhost:40000 https://internal.gtowiz.com/...
+```


### PR DESCRIPTION
## Summary
Extract the existing \`setup-warp\` composite action from \`web-universe/.github/actions/setup-warp\` so other repos can reuse it. First consumer is \`gto-wizard\`'s daily scraper-detection workflow, which currently 403s every Grafana call because GH-hosted runners can't reach \`grafana.gtowiz.com\` without a tunnel.

## What it does
Installs \`cloudflare-warp\` on Ubuntu, writes \`/var/lib/cloudflare-warp/mdm.xml\` with \`mode=proxy\`, starts \`warp-svc\`, and connects via \`warp-cli\` using Cloudflare Access service-token MDM auth. Proxy listens on \`localhost:40000\` by default — consumers route requests via \`curl --proxy http://localhost:40000\` or by exporting \`HTTP_PROXY\`/\`HTTPS_PROXY\`.

## Why centralize
Slack thread (Anton ↔ Tamas, 2026-05-05): scraper-detection in gto-wizard is the second known consumer; rakeback-wizard, ema, and any future repo that needs internal-network access from GH Actions will be the third. Tamas suggested extraction; this PR does it.

## Source
Verbatim copy of [web-universe@master:.github/actions/setup-warp/action.yaml](https://github.com/gto-wizard/web-universe/blob/master/.github/actions/setup-warp/action.yaml). web-universe can swap to consume \`gto-wizard/actions-templates/.github/actions/setup-warp@main\` in a follow-up — not blocking on it.

## Test plan
- [ ] Merge this PR.
- [ ] Reference from gto-wizard scraper-detection (companion PR opens against \`gto-wizard\` next) and confirm Grafana \`/api/datasources\` probe returns 200 from a CI run.
- [ ] (Follow-up, owned by Tamas) Migrate web-universe \`ai-e2e-tests.yml\` to consume the central version and delete the local copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a GitHub Actions utility to install and configure Cloudflare WARP in proxy mode for accessing internal services.

* **Documentation**
  * Added usage guide and examples for the Cloudflare WARP action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->