### PR TITLE
fix(argocd-sync-wait): use public endpoint as default server URL (OPS-505)

### DIFF
--- a/.github/actions/argocd-sync-wait/action.yaml
+++ b/.github/actions/argocd-sync-wait/action.yaml
@@ -2,7 +2,7 @@ name: 🗘 Argocd sync and wait
 inputs:
   ARGOCD_SERVER_URL:
     type: string
-    default: grpc-argocd.services.gtowiz.com
+    default: argocd.services.gtowiz.com
     description: Argocd server endpoint url.
   ARGOCD_VERSION:
     type: string


### PR DESCRIPTION
## Summary

- Switch the `argocd-sync-wait` composite action default `ARGOCD_SERVER_URL` from `grpc-argocd.services.gtowiz.com` (private DNS, services-cluster-only) to `argocd.services.gtowiz.com` (public endpoint).
- Unblocks CI cluster runners that cannot resolve the private DNS name; the public endpoint becomes reachable for them once their NAT IPs are whitelisted (parallel change in the `terraform` repo).

## Linear Ticket

Refs: [OPS-505](https://linear.app/gto-wizard/issue/OPS-505)

## Related PRs

| PR | Repo | Status |
|----|------|--------|
| [terraform-modules#153](https://github.com/gto-wizard/terraform-modules/pull/153) | terraform-modules | ✅ Merged — wires `argocd_public_ingress_whitelist` into SecurityPolicy |
| [k8s-resources#8747](https://github.com/gto-wizard/k8s-resources/pull/8747) | k8s-resources | ✅ Merged — removes raw SecurityPolicy manifest (now managed by Terraform) |
| [terraform#741](https://github.com/gto-wizard/terraform/pull/741) | terraform | 🔄 Open — bumps to `aws-argocd-v0.19.0`, adds CI NAT EIPs to whitelist |
| **this PR** | actions-templates | 🔄 Open — switch to public endpoint default |

Merge order: terraform-modules#153 → k8s-resources#8747 → terraform#741 → this PR

## Environments Affected

- [ ] dev
- [ ] prod
- [ ] Both
- [x] N/A (module/template — no direct environment impact)

## Changes

- `.github/actions/argocd-sync-wait/action.yaml`: change default value of input `ARGOCD_SERVER_URL` from `grpc-argocd.services.gtowiz.com` to `argocd.services.gtowiz.com`.

No other references to the old hostname exist in this repo.

## Validation

- [ ] tg-apply plan reviewed (Terraform repos)
- [ ] kubectl apply --dry-run=client passed (K8s repos)
- [x] No hardcoded secrets — all sensitive values via AWS Secrets Manager / env refs

This is a YAML-only composite action change; validation happens at consumer-repo level. Consumers still on services-cluster-only runners can override the input explicitly (back to `grpc-argocd.services.gtowiz.com`) if needed; consumers running on CI cluster runners will inherit the new public default once they bump their SHA pin.

## Rollback Plan

Revert this commit. The default reverts to the private endpoint; any consumer already passing an explicit `ARGOCD_SERVER_URL` is unaffected either way.

## Checklist

- [x] PR title follows `type(module/env): [ISSUE-ID] description`
- [x] Linear ticket referenced above
- [x] `review-devops` label added to this PR

## Follow-up

Do NOT bump SHA pins in downstream repos as part of this PR — that is a separate follow-up once this merges and the parallel `terraform` NAT whitelist change is in place.