### PR TITLE
ci(build-multi): add opt-in PR_HEAD_SHA input for PR head-sha tagging [PA-20]

### DIFF
--- a/.github/workflows/build-multi.yaml
+++ b/.github/workflows/build-multi.yaml
@@ -26,6 +26,11 @@ on:
         type: boolean
         default: true
         description: Push the build result to registry
+      PR_HEAD_SHA:
+        required: false
+        type: boolean
+        default: false
+        description: On pull_request, tag type=sha with the PR head sha instead of the ephemeral merge commit. No effect on push events. Default false keeps docker/metadata-action's default (merge commit).
       DOCKER_BUILD_ARGS:
         type: string
         description: List of build-time variables
@@ -74,6 +79,8 @@ jobs:
   build:
     name: 🐋 Build image - ${{ matrix.platform }}
     runs-on: ${{ matrix.platform == 'linux/amd64' && inputs.RUNS_ON_LABEL_AMD64 || matrix.platform == 'linux/arm64' && inputs.RUNS_ON_LABEL_ARM64 }}
+    env:
+      DOCKER_METADATA_PR_HEAD_SHA: ${{ inputs.PR_HEAD_SHA }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +197,8 @@ jobs:
     name: 🥨 Merge manifests
     if: ${{ inputs.DOCKER_PUSH }}
     runs-on: ubuntu-latest
+    env:
+      DOCKER_METADATA_PR_HEAD_SHA: ${{ inputs.PR_HEAD_SHA }}
     needs:
       - build
     permissions:


### PR DESCRIPTION
## What
Add an opt-in `PR_HEAD_SHA` input (boolean, **default `false`**) to the shared multi-arch builder `build-multi.yaml`, wired to `DOCKER_METADATA_PR_HEAD_SHA` via a **job-level `env:`** on both the `build` and `merge` jobs. When a caller sets `PR_HEAD_SHA: true`, `docker/metadata-action`'s `type=sha` tags `pull_request` builds with the PR **head** sha instead of the ephemeral merge commit.

## Why
[PA-20](https://linear.app/gto-wizard/issue/PA-20/build-preview-be-image-multi-arch-via-actions-templates-build): the PokerArena per-PR preview env adopts this shared multi-arch builder (replacing a bespoke amd64-only action that caused `ImagePullBackOff` on arm64 Graviton nodes). Its ArgoCD ApplicationSet references the image by `{{ .head_sha | trunc 7 }}` — derivable from PR metadata — so it opts in with `PR_HEAD_SHA: true`.

## Safety / blast radius
- **Default `false` = zero behavior change for any consumer**, even after bumping the pin (`false` → metadata-action's default merge-commit `type=sha`). Verified against the pinned `docker/metadata-action@…v5.7.0` source: the head-sha override is gated on `/true/i` and only fires on `pull_request` events.
- `push`, `latest`, and branch tags are unaffected; the only change is the `type=sha` tag/label value, and only when a caller opts in.
- Set on both jobs so the published manifest tag (merge) and the per-arch `revision` label (build) reference the same sha.

## Notes
- The QEMU sibling `build-multi-qemu.yaml` was intentionally **not** given this input — PA-20 scopes to the native-runner builder the preview uses. Add it there later if a QEMU consumer needs PR-head-sha tagging.

## Review
Reviewed locally (blast-radius-analyzer → code-reviewer, incl. a re-review of the input revision): **ACCEPT**, no BLOCKER/SECURITY/MAJOR/MINOR. gtowbot honors the local-review receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the multi-image build workflow to support optional PR-head-SHA tagging for Docker image metadata.
  * Added a new workflow input to control whether tagging uses the PR head SHA (when enabled) instead of an ephemeral merge commit, improving consistency across build and merge jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->